### PR TITLE
Add startProcess helper and update tests

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -410,6 +410,11 @@ extension LinuxContainer {
         get { config.spec.process!.rlimits }
         set { config.spec.process!.rlimits = newValue }
     }
+
+    /// PID of the container's init process, or -1 if not running.
+    public var pid: Int32 {
+        (try? state.startedState("pid").process.pid) ?? -1
+    }
 }
 
 extension LinuxContainer {

--- a/Sources/Integration/ProcessTests.swift
+++ b/Sources/Integration/ProcessTests.swift
@@ -35,6 +35,9 @@ extension IntegrationSuite {
 
         try await container.create()
         try await container.start()
+        guard container.pid > 0 else {
+            throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+        }
 
         let status = try await container.wait()
         try await container.stop()
@@ -53,6 +56,9 @@ extension IntegrationSuite {
 
         try await container.create()
         try await container.start()
+        guard container.pid > 0 else {
+            throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+        }
 
         let status = try await container.wait()
         try await container.stop()
@@ -85,6 +91,12 @@ extension IntegrationSuite {
         do {
             try await container.create()
             try await container.start()
+            guard container.pid > 0 else {
+                throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+            }
+            guard container.pid > 0 else {
+                throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+            }
 
             let status = try await container.wait()
             try await container.stop()
@@ -117,6 +129,9 @@ extension IntegrationSuite {
         do {
             try await container.create()
             try await container.start()
+            guard container.pid > 0 else {
+                throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+            }
 
             let execConfig = ContainerizationOCI.Process(
                 args: ["/bin/true"],
@@ -132,6 +147,9 @@ extension IntegrationSuite {
 
                     group.addTask {
                         try await exec.start()
+                        guard exec.pid > 0 else {
+                            throw IntegrationError.assert(msg: "invalid pid \(exec.pid)")
+                        }
                         let status = try await exec.wait()
                         if status != 0 {
                             throw IntegrationError.assert(msg: "process status \(status) != 0")
@@ -190,6 +208,9 @@ extension IntegrationSuite {
                             stdout: buffer,
                         )
                         try await exec.start()
+                        guard exec.pid > 0 else {
+                            throw IntegrationError.assert(msg: "invalid pid \(exec.pid)")
+                        }
 
                         let status = try await exec.wait()
                         if status != 0 {
@@ -237,6 +258,9 @@ extension IntegrationSuite {
 
         try await container.create()
         try await container.start()
+        guard container.pid > 0 else {
+            throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+        }
 
         let status = try await container.wait()
         try await container.stop()
@@ -269,6 +293,9 @@ extension IntegrationSuite {
 
         try await container.create()
         try await container.start()
+        guard container.pid > 0 else {
+            throw IntegrationError.assert(msg: "invalid pid \(container.pid)")
+        }
 
         let status = try await container.wait()
         try await container.stop()

--- a/vminitd/Sources/vminitd/ManagedContainer.swift
+++ b/vminitd/Sources/vminitd/ManagedContainer.swift
@@ -106,6 +106,17 @@ extension ManagedContainer {
         try self.initProcess.start()
     }
 
+    func startProcess(id: String) async throws -> Int32 {
+        let proc: ManagedProcess
+        if id == self.id {
+            proc = self.initProcess
+        } else {
+            try ensureExecExists(id)
+            proc = self._execs[id]!
+        }
+        return try await ProcessSupervisor.default.start(process: proc)
+    }
+
     func wait() async -> Int32 {
         await self.initProcess.wait()
     }

--- a/vminitd/Sources/vminitd/Server+GRPC.swift
+++ b/vminitd/Sources/vminitd/Server+GRPC.swift
@@ -516,20 +516,8 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContextAsyncProvid
 
         do {
             let ctr = try await self.state.get(container: request.containerID)
-
-            // FIXME: This should just happen inside of ManagedContainer.
-            let pid: Int32
-            if request.id == request.containerID {
-                let process = ctr.initProcess
-                pid = try await ProcessSupervisor.default.start(process: process)
-            } else {
-                let process = try await ctr.getExec(id: request.id)
-                pid = try await ProcessSupervisor.default.start(process: process)
-            }
-
-            return .with {
-                $0.pid = pid
-            }
+            let pid = try await ctr.startProcess(id: request.id)
+            return .with { $0.pid = pid }
         } catch {
             log.error(
                 "startProcess",


### PR DESCRIPTION
## Summary
- manage process startup within `ManagedContainer`
- delegate gRPC `startProcess` to the container helper
- expose container init PID
- assert pid values in integration tests

## Testing
- `swift test --list-tests` *(fails: cannot compile due to missing system headers)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2366c30832a8318ee08a4ec45a6