### PR TITLE
Deterministic UnixSocketConfiguration id

### DIFF
--- a/Sources/Containerization/UnixSocketConfiguration.swift
+++ b/Sources/Containerization/UnixSocketConfiguration.swift
@@ -15,17 +15,17 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import Crypto
 import Foundation
 import SystemPackage
 
 /// Represents a UnixSocket that can be shared into or out of a container/guest.
-public struct UnixSocketConfiguration: Sendable {
-    // TODO: Realistically, we can just hash this struct and use it as the "id".
+public struct UnixSocketConfiguration: Sendable, Hashable {
     package var id: String {
-        _id
+        let toHash = "src:\(source.path)|dst:\(destination.path)|perm:\(permissions?.rawValue ?? 0)|dir:\(direction)"
+        let data = Data(toHash.utf8)
+        return String(SHA256.hash(data: data).encoded.prefix(36))
     }
-
-    private let _id = UUID().uuidString
 
     /// The path to the socket you'd like relayed. For .into
     /// direction this should be the path on the host to a unix socket.

--- a/Tests/ContainerizationTests/UnixSocketConfigurationTests.swift
+++ b/Tests/ContainerizationTests/UnixSocketConfigurationTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import Containerization
+
+struct UnixSocketConfigurationTests {
+    @Test
+    func deterministicIDs() {
+        let src = URL(fileURLWithPath: "/tmp/source.sock")
+        let dst = URL(fileURLWithPath: "/tmp/dest.sock")
+        let perms = FilePermissions(rawValue: 0o644)
+        let c1 = UnixSocketConfiguration(source: src, destination: dst, permissions: perms, direction: .into)
+        let c2 = UnixSocketConfiguration(source: src, destination: dst, permissions: perms, direction: .into)
+        #expect(c1.id == c2.id)
+
+        var c3 = c1
+        c3.destination = URL(fileURLWithPath: "/tmp/other.sock")
+        #expect(c1.id != c3.id)
+
+        let set: Set<UnixSocketConfiguration> = [c1, c2, c3]
+        #expect(set.count == 2)
+    }
+}


### PR DESCRIPTION
## Summary
- derive a stable `id` for `UnixSocketConfiguration` from its fields
- conform `UnixSocketConfiguration` to `Hashable`
- add a unit test verifying deterministic id generation

## Testing
- `swift test -l` *(fails: cannot compile due to missing headers and EPOLL definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6847d4ff11e0832aa7b2900154b456d7